### PR TITLE
Properly convert Record to array

### DIFF
--- a/lib/phpcouch/record/Record.php
+++ b/lib/phpcouch/record/Record.php
@@ -162,10 +162,26 @@ class Record implements RecordInterface, \ArrayAccess
 		$retval = array();
 		
 		foreach($this->data as $key => $value) {
-			$retval[$key] = $this->__get($key);
+			$val = $this->__get($key);
+			if (is_object($val)) {
+				$val = $this->objectToArray($val);
+			}
+			$retval[$key] = $val;
 		}
-		
 		return $retval;
+	}
+	
+	protected function objectToArray($obj)
+	{
+		if (is_object($obj)) {
+			$obj = get_object_vars($obj);
+		}
+		if (is_array($obj)) {
+			return array_map(array($this, 'objectToArray'), $obj);
+		}
+		else {
+			return $obj;
+		}
 	}
 	
 	/**


### PR DESCRIPTION
The current implementation of Record::toArray() only makes an array of the first level of the data.

If however your json contains associative data that nests many levels, they are represented as stdClass objects. I think this is unexpected and undesired for a toArray() method.

This function recursively makes arrays of the whole json.
