### PR TITLE
add composer.json for packagist support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "dzuelke/PHPCouch",
+    "type": "library",
+    "description": "A CouchDB library for PHP",
+    "homepage": "https://github.com/dzuelke/PHPCouch",
+    "license": "MIT",
+    "authors": [
+        {"name":"Simon Thulbourn"},
+        {"name":"Niklas Närhinen","email":"niklas@narhinen.net","homepage":"http://narhinen.net"}
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    }
+}


### PR DESCRIPTION
We should IMO be supporting the movement towards http://packagist.org/

It should be discussed, though what the repo should be called (dzuelke/PHPCouch, dzuelke/phpcouch, sthulbourn/phpcouch, phpcouch/phpcouch, agavi/phpcouch, ecomfi/phocouch..) :)
