### PR TITLE
Recurse on arrays of objects in Record::toArray()

### DIFF
--- a/lib/phpcouch/record/Record.php
+++ b/lib/phpcouch/record/Record.php
@@ -163,9 +163,7 @@ class Record implements RecordInterface, \ArrayAccess
 		
 		foreach($this->data as $key => $value) {
 			$val = $this->__get($key);
-			if (is_object($val)) {
-				$val = $this->objectToArray($val);
-			}
+			$val = $this->objectToArray($val);
 			$retval[$key] = $val;
 		}
 		return $retval;


### PR DESCRIPTION
This is a breaking change, but I think the current behaviour is pretty inconsistent: Right now, arrays of `stdClass` (created by `json_decode`) aren't converted to arrays of associative arrays by `toArray()`.