### PR TITLE
Fix getDocument() for views that emit values

### DIFF
--- a/lib/phpcouch/record/ViewResultRow.php
+++ b/lib/phpcouch/record/ViewResultRow.php
@@ -42,7 +42,8 @@ class ViewResultRow extends Record implements ViewResultRowInterface
 		if($accessor === null) {
 			// the value contains the document itself
 			$doc = $this->value;
-			if (!$doc) { // if the view didn't emit the actual doc as value but was called with include_docs=true
+			// if the view didn't emit the actual doc as value but was called with include_docs=true
+			if(!$doc || (!isset($doc->_id) && !isset($doc['_id']))) {
 				$doc = $this->doc;
 			}
 		} elseif(is_callable($accessor)) {


### PR DESCRIPTION
A view could e.g. emit a scalar or an object with other data (e.g. `emit("mykey", 1);`) – still `getDocument()` should return the associated document.