### PR TITLE
Append response text to HttpErrorException message

### DIFF
--- a/lib/phpcouch/http/HttpErrorException.php
+++ b/lib/phpcouch/http/HttpErrorException.php
@@ -8,6 +8,8 @@ class HttpErrorException extends \RuntimeException implements \phpcouch\Exceptio
 	
 	public function __construct($message, $code, \phpcouch\http\HttpResponse $response = null, \Exception $previous = null)
 	{
+		$message = $message . "\n" . $response->getContent();
+		
 		parent::__construct($message, $code, $previous);
 		
 		$this->response = $response;


### PR DESCRIPTION
The HTTP status alone doesn't help that much when found in log files, so I propose we include the error response content from the server as well, e.g. instead of

> HTTP/1.1 400 Bad Request

we will now have

> HTTP/1.1 400 Bad Request
> {"error":"query_parse_error","reason":"No rows can match your key range, reverse your start_key and end_key or set descending=true"}

in the logs.